### PR TITLE
Fix control-flow exceptions in pytest.warns() blocks

### DIFF
--- a/changelog/11907.bugfix.rst
+++ b/changelog/11907.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a regression where control-flow exceptions like ``pytest.skip``, ``pytest.fail``, ``pytest.xfail``, and ``pytest.exit``, as well as system-level exceptions like ``KeyboardInterrupt``, were being suppressed when raised inside a ``pytest.warns()`` block. 

--- a/src/_pytest/recwarn.py
+++ b/src/_pytest/recwarn.py
@@ -21,6 +21,7 @@ import warnings
 from _pytest.deprecated import check_ispytest
 from _pytest.deprecated import WARNS_NONE_ARG
 from _pytest.fixtures import fixture
+from _pytest.outcomes import Exit
 from _pytest.outcomes import fail
 
 
@@ -304,6 +305,12 @@ class WarningsChecker(WarningsRecorder):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
+        # Let control-flow exceptions and system-level exceptions propagate
+        if exc_type is not None and (
+            not issubclass(exc_type, Exception) or issubclass(exc_type, Exit)
+        ):
+            return False
+
         super().__exit__(exc_type, exc_val, exc_tb)
 
         __tracebackhide__ = True


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [ ] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
